### PR TITLE
Added 'mode' option to insert hash as part of the URL path.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Options with default values shown:
       assetRoot: '',
       assetURL: '/',
       tokenRegExp: /ASSET{(.*?)}/g,
-      hashLength: 8
+      hashLength: 8,
+      mode: 0
     })
 
 - `env`: the target environment for the current build
@@ -34,6 +35,17 @@ Options with default values shown:
 - `hashLength`: the number of characters to use from the asset's hash digest
     - With the default value this plugin will generate url's like so: `background-image: url(http://cdn.example.com/assets/images/pingu.jpg?v=df23b44e});`
     - This option is usually left as-is
+- `mode`: controls how the hash is added to the URL
+	- 0 (Default) - append the hash as a query parameter.
+	- 1 - insert the hash as part of the URL path, before the filename. e.g. `http://cdn.example.com/assets/images/v-df23b44e/pingu.jpg`. NOTE: use this mode only if your CDN/proxy ignores key caching by query parameters. You will also need a webserver URL rewrite rule to discard the /v-xxxxxxxx/ portion of the URL, before incoming HTTP requests are processed. For IIS, the rewrite rule looks like this: 
+    
+		````
+		<rule name="cachebust">
+		  <match url="([\S]+)(/v-[0-9]+/)([\S]+)" />
+		  <action type="Rewrite" url="{R:1}/{R:3}" />
+		</rule>
+		````
+
 
 If the plugin encounters an asset path that is not present in the `hashes`
 mapping, the plugin will not add the url query parameter

--- a/index.js
+++ b/index.js
@@ -13,7 +13,8 @@ var defaults = {
   assetRoot: '',
   assetURL: '/',
   tokenRegExp: /ASSET{(.*?)}/g,
-  hashLength: 8
+  hashLength: 8,
+  mode: 0
 };
 
 
@@ -47,7 +48,12 @@ var plugin = function(options) {
     }
     u.pathname += assetPath;
     if (digest) {
-      u.query = _.extend({}, u.query, {v: digest.substr(0, opts.hashLength)});
+      if (opts.mode == 0) {
+        u.query = _.extend({}, u.query, {v: digest.substr(0, opts.hashLength)});
+      } else if (opts.mode == 1) {
+        var index = u.pathname.lastIndexOf('/');
+        u.pathname = u.pathname.slice(0, index) + '/v-' + digest.substr(0, opts.hashLength) + u.pathname.slice(index, u.pathname.length);	        
+      }    
     }
     return url.format(u);
   };


### PR DESCRIPTION
Some CDN/proxy do not support or ignore the query parameters on the URL as cache key. Therefore, to them, image.jpg?v=1 and image.jpg?v=2 are using the same key. I added a new 'mode' option, when set to 1, will insert the hash as part of the URL path (e.g. /v-1/image.jpg vs /v-2/image.jpg). 

The caveat is for cache busting to work, URL rewrite rules will need to be configured properly in order to discard the hash part of the URL before the HTTP request is processed.

For backward compatibility, the mode is set to 0 by default and will insert the hash as query parameter.
