### PR TITLE
add check for null in pathname in assetURL

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,11 @@ var plugin = function(options) {
     if (options.env === 'production') {
       assetPath = getProductionPath(assetPath, args);
     }
-    u.pathname += assetPath;
+    if(u.pathname != null) {
+      u.pathname += assetPath;
+    } else {
+      u.pathname = assetPath;
+    }
     if (digest) {
       u.query = _.extend({}, u.query, {v: digest.substr(0, opts.hashLength)});
     }

--- a/index.js
+++ b/index.js
@@ -13,7 +13,8 @@ var defaults = {
   assetRoot: '',
   assetURL: '/',
   tokenRegExp: /ASSET{(.*?)}/g,
-  hashLength: 8
+  hashLength: 8,
+  removeToken: true
 };
 
 
@@ -52,6 +53,9 @@ var plugin = function(options) {
     }
     if (digest) {
       u.query = _.extend({}, u.query, {v: digest.substr(0, opts.hashLength)});
+    }
+    if(options.removeToken === false) {
+      return match.replace(assetPath, url.format(u));
     }
     return url.format(u);
   };


### PR DESCRIPTION
When setting a blank assetURL, pathname in the parsed url was 'none'.
When converted to new url 'none' polluted the new url. 
